### PR TITLE
Adding support for import parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ var Inkscape = require('inkscape'),
 sourceStream.pipe(svgToPdfConverter).pipe(destinationStream);
 ```
 
+Import type can also be fed to the constructor (converting PDF to PNG):
+
+```javascript
+var Inkscape = require('inkscape'),
+    pdfToPngConverter = new Inkscape(['--export-png', '--export-width=1024', '--import-pdf']);
+
+sourceStream.pipe(pdfToPngConverter).pipe(destinationStream);
+```
+
 Inkscape as a web service (converts to a PNG):
 
 ```javascript

--- a/lib/Inkscape.js
+++ b/lib/Inkscape.js
@@ -73,6 +73,7 @@ function Inkscape(inkscapeArgs) {
     if (!this.inputFormat) {
         this.inputFormat = 'svg';
         this.inkscapeInputFilePath = getTemporaryFilePath({suffix: '.svg'});
+        this.inkscapeArgs.push(this.inkscapeInputFilePath);
     }
 
     this.filesToCleanUp = [];

--- a/lib/Inkscape.js
+++ b/lib/Inkscape.js
@@ -17,40 +17,63 @@ function Inkscape(inkscapeArgs) {
 
     this.hasEnded = false;
 
-    for (var i = 0 ; i < this.inkscapeArgs.length ; i += 1) {
-        var matchInkscapeArg = this.inkscapeArgs[i].match(/^(-e|-P|-E|-A|-l|--export-(?:plain-svg|png|ps|eps|pdf))(?:=|$)$/);
+    var setOutputFormat = false;
+    var setInputFormat = false;
+
+    var inkscapeArgsTemp = this.inkscapeArgs; // to make sure that the import parameters are not passed later to inkscape
+    this.inkscapeArgs = [];
+
+    for (var i = 0 ; i < inkscapeArgsTemp.length ; i += 1) {
+        var matchInkscapeArg = inkscapeArgsTemp[i].match(/^(-e|-P|-E|-A|-l|--export-(?:plain-svg|png|ps|eps|pdf)|--import-(?:plain-svg|png|ps|eps|pdf))(?:=|$)$/);
         if (matchInkscapeArg) {
-            var inkscapeArg = matchInkscapeArg[1];
-            if (inkscapeArg === '-e' || inkscapeArg === '--export-png') {
-                this.outputFormat = 'png';
-            } else if (inkscapeArg === '-A' || inkscapeArg === '--export-pdf') {
-                this.outputFormat = 'pdf';
-            } else if (inkscapeArg === '-E' || inkscapeArg === '--export-eps') {
-                this.outputFormat = 'eps';
-            } else if (inkscapeArg === '-P' || inkscapeArg === '--export-ps') {
-                this.outputFormat = 'ps';
-            } else if (inkscapeArg === '-l' || inkscapeArg === '--export-plain-svg') {
-                this.outputFormat = 'svg';
+            if (matchInkscapeArg[1] === '-e' || matchInkscapeArg[1] === '--export-png') {
+                this.outputFormat = 'png'; setOutputFormat = true; 
+            } else if (matchInkscapeArg[1] === '-A' || matchInkscapeArg[1] === '--export-pdf') {
+                this.outputFormat = 'pdf'; setOutputFormat = true;
+            } else if (matchInkscapeArg[1] === '-E' || matchInkscapeArg[1] === '--export-eps') {
+                this.outputFormat = 'eps'; setOutputFormat = true;
+            } else if (matchInkscapeArg[1] === '-P' || matchInkscapeArg[1] === '--export-ps') {
+                this.outputFormat = 'ps'; setOutputFormat = true;
+            } else if (matchInkscapeArg[1] === '-l' || matchInkscapeArg[1] === '--export-plain-svg') {
+                this.outputFormat = 'svg'; setOutputFormat = true;
+            } else if (matchInkscapeArg[1] === '--import-pdf') {
+                this.inputFormat = 'pdf'; setInputFormat = true;
+            } else if (matchInkscapeArg[1] === '--import-eps') {
+                this.inputFormat = 'eps'; setInputFormat = true;
+            } else if (matchInkscapeArg[1] === '--import-ps') {
+                this.inputFormat = 'ps'; setInputFormat = true;
+            } else if (matchInkscapeArg[1] === '--import-plain-svg') {
+                this.inputFormat = 'svg'; setInputFormat = true;
             } else {
-                throw new Error('Internal error: Unable to parse export switch: ' + inkscapeArg);
+                throw new Error('Internal error: Unable to parse switch: ' + inkscapeArg);
             }
 
-            this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat});
-
-            this.inkscapeArgs[i] = '--export-' + (this.outputFormat === 'svg' ? 'plain-' : '') + this.outputFormat + '=' + this.inkscapeOutputFilePath;
-            break;
+            if (setOutputFormat) {
+                this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat});
+                this.inkscapeArgs.push('--export-' + (this.outputFormat === 'svg' ? 'plain-' : '') + this.outputFormat + '=' + this.inkscapeOutputFilePath);
+                setOutputFormat = false;  
+            }
+            else if (setInputFormat) {
+                this.inkscapeInputFilePath = getTemporaryFilePath({suffix: "."+this.inputFormat});
+                this.inkscapeArgs.push(this.inkscapeInputFilePath);
+                setInputFormat = false;
+            }
+            else {
+                this.inkscapeArgs.push(inkscapeArgsTemp[i]);
+            }
         }
     }
-
+    
     if (!this.outputFormat) {
         this.outputFormat = 'png';
-        this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat});
+        this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat}),
         this.inkscapeArgs.push('-e=' + this.inkscapeOutputFilePath);
     }
 
-    this.inkscapeInputFilePath = getTemporaryFilePath({suffix: '.svg'});
-
-    this.inkscapeArgs.push(this.inkscapeInputFilePath);
+    if (!this.inputFormat) {
+        this.inputFormat = 'svg';
+        this.inkscapeInputFilePath = getTemporaryFilePath({suffix: '.svg'});
+    }
 
     this.filesToCleanUp = [];
 }
@@ -75,7 +98,7 @@ Inkscape.prototype.write = function (chunk) {
         this.filesToCleanUp.push(this.inkscapeInputFilePath);
         this.writeStream = fs.createWriteStream(this.inkscapeInputFilePath);
         this.writeStream.on('error', function (err) {
-            this.cleanUp();
+            cleanUp();
             this._reportError(err);
         }.bind(this));
     }

--- a/lib/Inkscape.js
+++ b/lib/Inkscape.js
@@ -58,9 +58,9 @@ function Inkscape(inkscapeArgs) {
                 this.inkscapeArgs.push(this.inkscapeInputFilePath);
                 setInputFormat = false;
             }
-            else {
-                this.inkscapeArgs.push(inkscapeArgsTemp[i]);
-            }
+        }
+        else {
+            this.inkscapeArgs.push(inkscapeArgsTemp[i]);
         }
     }
     

--- a/lib/Inkscape.js
+++ b/lib/Inkscape.js
@@ -26,23 +26,24 @@ function Inkscape(inkscapeArgs) {
     for (var i = 0 ; i < inkscapeArgsTemp.length ; i += 1) {
         var matchInkscapeArg = inkscapeArgsTemp[i].match(/^(-e|-P|-E|-A|-l|--export-(?:plain-svg|png|ps|eps|pdf)|--import-(?:plain-svg|png|ps|eps|pdf))(?:=|$)$/);
         if (matchInkscapeArg) {
-            if (matchInkscapeArg[1] === '-e' || matchInkscapeArg[1] === '--export-png') {
+            var inkscapeArg = matchInkscapeArg[1];
+            if (inkscapeArg === '-e' || inkscapeArg === '--export-png') {
                 this.outputFormat = 'png'; setOutputFormat = true; 
-            } else if (matchInkscapeArg[1] === '-A' || matchInkscapeArg[1] === '--export-pdf') {
+            } else if (inkscapeArg === '-A' || inkscapeArg === '--export-pdf') {
                 this.outputFormat = 'pdf'; setOutputFormat = true;
-            } else if (matchInkscapeArg[1] === '-E' || matchInkscapeArg[1] === '--export-eps') {
+            } else if (inkscapeArg === '-E' || inkscapeArg === '--export-eps') {
                 this.outputFormat = 'eps'; setOutputFormat = true;
-            } else if (matchInkscapeArg[1] === '-P' || matchInkscapeArg[1] === '--export-ps') {
+            } else if (inkscapeArg === '-P' || inkscapeArg === '--export-ps') {
                 this.outputFormat = 'ps'; setOutputFormat = true;
-            } else if (matchInkscapeArg[1] === '-l' || matchInkscapeArg[1] === '--export-plain-svg') {
+            } else if (inkscapeArg === '-l' || inkscapeArg === '--export-plain-svg') {
                 this.outputFormat = 'svg'; setOutputFormat = true;
-            } else if (matchInkscapeArg[1] === '--import-pdf') {
+            } else if (inkscapeArg === '--import-pdf') {
                 this.inputFormat = 'pdf'; setInputFormat = true;
-            } else if (matchInkscapeArg[1] === '--import-eps') {
+            } else if (inkscapeArg === '--import-eps') {
                 this.inputFormat = 'eps'; setInputFormat = true;
-            } else if (matchInkscapeArg[1] === '--import-ps') {
+            } else if (inkscapeArg === '--import-ps') {
                 this.inputFormat = 'ps'; setInputFormat = true;
-            } else if (matchInkscapeArg[1] === '--import-plain-svg') {
+            } else if (inkscapeArg === '--import-plain-svg') {
                 this.inputFormat = 'svg'; setInputFormat = true;
             } else {
                 throw new Error('Internal error: Unable to parse switch: ' + inkscapeArg);
@@ -66,7 +67,7 @@ function Inkscape(inkscapeArgs) {
     
     if (!this.outputFormat) {
         this.outputFormat = 'png';
-        this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat}),
+        this.inkscapeOutputFilePath = getTemporaryFilePath({suffix: '.' + this.outputFormat});
         this.inkscapeArgs.push('-e=' + this.inkscapeOutputFilePath);
     }
 

--- a/lib/Inkscape.js
+++ b/lib/Inkscape.js
@@ -98,7 +98,7 @@ Inkscape.prototype.write = function (chunk) {
         this.filesToCleanUp.push(this.inkscapeInputFilePath);
         this.writeStream = fs.createWriteStream(this.inkscapeInputFilePath);
         this.writeStream.on('error', function (err) {
-            cleanUp();
+            this.cleanUp();
             this._reportError(err);
         }.bind(this));
     }


### PR DESCRIPTION
Sometimes it is important to specify the import parameter also (especially when one would not like to convert from SVG rather from a different format).

Parameter styling follows the export parameters: --import-*
